### PR TITLE
allow 2gb of ram for RailDigitraffic2GTFSRT

### DIFF
--- a/digitransit-azure-deploy/files/raildigitraffic2gtfsrt-dev.json
+++ b/digitransit-azure-deploy/files/raildigitraffic2gtfsrt-dev.json
@@ -2,7 +2,7 @@
   "id": "/raildigitraffic2gtfsrt",
   "cmd": null,
   "cpus": 0.1,
-  "mem": 1000,
+  "mem": 2048,
   "disk": 0,
   "instances": 2,
   "container": {

--- a/digitransit-azure-deploy/files/raildigitraffic2gtfsrt-prod.json
+++ b/digitransit-azure-deploy/files/raildigitraffic2gtfsrt-prod.json
@@ -2,7 +2,7 @@
   "id": "/raildigitraffic2gtfsrt",
   "cmd": null,
   "cpus": 1,
-  "mem": 1000,
+  "mem": 2048,
   "disk": 0,
   "instances": 4,
   "container": {


### PR DESCRIPTION
currently fails to start with 1g ram