### PR TITLE
Use new gc settings in dev otp

### DIFF
--- a/digitransit-azure-deploy/files/opentripplanner-finland-dev.json
+++ b/digitransit-azure-deploy/files/opentripplanner-finland-dev.json
@@ -42,7 +42,7 @@
   "env": {
       "ROUTER_DATA_CONTAINER_URL": "https://dev-api.digitransit.fi/routing-data/v2/finland",
       "ROUTER_NAME": "finland",
-      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -Xmx7G -Xms7G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:G1ReservePercent=10"
+      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -XX:+UseParNewGC -Xms7G -Xmx7G -XX:NewRatio=5 -XX:+UseStringDeduplication -XX:+UseStringCache"
   },
   "gpus": 0,
   "healthChecks": [
@@ -81,6 +81,6 @@
   "taskKillGracePeriodSeconds": null,
   "upgradeStrategy": {
       "maximumOverCapacity": 1,
-      "minimumHealthCapacity": 0
+      "minimumHealthCapacity": 0.5
   }
 }

--- a/digitransit-azure-deploy/files/opentripplanner-hsl-dev.json
+++ b/digitransit-azure-deploy/files/opentripplanner-hsl-dev.json
@@ -42,7 +42,7 @@
   "env": {
       "ROUTER_DATA_CONTAINER_URL": "https://dev-api.digitransit.fi/routing-data/v2/hsl",
       "ROUTER_NAME": "hsl",
-      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -Xmx7G -Xms7G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:G1ReservePercent=10"
+      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -XX:+UseParNewGC -Xms7G -Xmx7G -XX:NewRatio=5 -XX:+UseStringDeduplication -XX:+UseStringCache"
   },
   "gpus": 0,
   "healthChecks": [
@@ -81,6 +81,6 @@
   "taskKillGracePeriodSeconds": null,
   "upgradeStrategy": {
       "maximumOverCapacity": 1,
-      "minimumHealthCapacity": 0
+      "minimumHealthCapacity": 0.5
   }
 }

--- a/digitransit-azure-deploy/files/opentripplanner-next-dev.json
+++ b/digitransit-azure-deploy/files/opentripplanner-next-dev.json
@@ -40,7 +40,7 @@
     "dependencies": [],
     "disk": 0,
     "env": {
-        "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -Xmx10G -Xms10G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:G1ReservePercent=10",
+        "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -XX:+UseParNewGC -Xms10G -Xmx10G -XX:NewRatio=5 -XX:+UseStringDeduplication -XX:+UseStringCache",
         "ROUTER_DATA_CONTAINER_URL": "https://dev-api.digitransit.fi/routing-data/v2/hsl",
         "ROUTER_NAME": "hsl"
     },

--- a/digitransit-azure-deploy/files/opentripplanner-waltti-dev.json
+++ b/digitransit-azure-deploy/files/opentripplanner-waltti-dev.json
@@ -42,7 +42,7 @@
   "env": {
       "ROUTER_DATA_CONTAINER_URL": "https://dev-api.digitransit.fi/routing-data/v2/waltti",
       "ROUTER_NAME": "waltti",
-      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -Xmx7G -Xms7G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:G1ReservePercent=10"
+      "JAVA_OPTS": "-Dsentry.dsn=sentry_routing_secret_dsn -XX:+UseParNewGC -Xms7G -Xmx7G -XX:NewRatio=5 -XX:+UseStringDeduplication -XX:+UseStringCache"
   },
   "gpus": 0,
   "healthChecks": [
@@ -81,6 +81,6 @@
   "taskKillGracePeriodSeconds": null,
   "upgradeStrategy": {
       "maximumOverCapacity": 1,
-      "minimumHealthCapacity": 0
+      "minimumHealthCapacity": 0.5
   }
 }


### PR DESCRIPTION
* Use new garbage collector options in dev otp instances
* Don't kill all dev otp instances when restarting the service